### PR TITLE
append additional attributes for mail addresses

### DIFF
--- a/lavatar/__init__.py
+++ b/lavatar/__init__.py
@@ -23,12 +23,12 @@ ldap_conn = LDAPConn(app)
 
 
 class User(ldap_conn.Entry):
-
     base_dn = app.config['LDAP_USER_BASEDN']
     object_class = app.config['LDAP_USER_OBJECTCLASS']
-
     mail = ldap_conn.Attribute(app.config['LDAP_USER_ATTR_MAIL'])
     photo = ldap_conn.Attribute(app.config['LDAP_USER_ATTR_PHOTO'])
+    alias = ldap_conn.Attribute(app.config["LDAP_USER_ATTR_ALIAS"])
+    mailAlternateAddress = ldap_conn.Attribute(app.config["LDAP_USER_ATTR_MAILALTERNATES"])
 
 
 # md5sum thread
@@ -40,11 +40,23 @@ def update_md5db_thread():
         users = User.query.filter(
             'mail: *, photo: *'
         ).filter(search_filter).all()
-
         for user in users:
             mailaddresses = user.mail
+            aliases = user.alias
+            mailAlternates = user.mailAlternateAddress
+            if aliases == None: aliases = []
+            if mailAlternates == None: mailAlternates = []
+
             if isinstance(mailaddresses, text_type):
                 mailaddresses = [mailaddresses]
+
+            if isinstance(aliases, text_type):
+                aliases = [aliases]
+
+            if isinstance(mailAlternates, text_type):
+                mailAlternates = [mailAlternates]
+
+            mailaddresses = mailaddresses + aliases + mailAlternates
 
             for mailaddr in mailaddresses:
                 ttl = int(app.config['MD5DB_ENTRY_TTL'])

--- a/lavatar/default_settings.py
+++ b/lavatar/default_settings.py
@@ -29,6 +29,8 @@ LDAP_USER_OBJECTCLASS = os.environ.get('LDAP_USER_OBJECTCLASS',
                                        'inetOrgPerson')
 LDAP_USER_SEARCHFILTER = os.environ.get('LDAP_USER_SEARCHFILTER', '')
 LDAP_USER_ATTR_MAIL = os.environ.get('LDAP_USER_ATTR_MAIL', 'mail')
+LDAP_USER_ATTR_ALIAS = os.environ.get('LDAP_USER_ATTR_ALIAS', 'alias')
+LDAP_USER_ATTR_MAILALTERNATES = os.environ.get('LDAP_USER_ATTR_MAILALTERNATES', 'mailAlternateAddress')
 LDAP_USER_ATTR_PHOTO = os.environ.get('LDAP_USER_ATTR_PHOTO', 'jpegPhoto')
 
 # E-Mail MD5 Database Settings


### PR DESCRIPTION
alias and mailAlternateAddress are probably not the only attributes
containing mail-addresses besides the LDAP mail attribute, so this might be incomplete. I couldn't implement a proper fix in short time though, so there likely is a better implementation.

This proof of concept works for me(tm) though, so this is up for
discussion.