### PR TITLE
Image.open wants to use paths

### DIFF
--- a/lavatar/avatar/__init__.py
+++ b/lavatar/avatar/__init__.py
@@ -89,13 +89,13 @@ def get_avatar(md5):
         default_image = current_app.config['AVATAR_DEFAULT_IMAGE']
         keyword = _get_argval_from_request(default_args, default_image)
         static_images = current_app.config['AVATAR_STATIC_IMAGES']
+        static_path = current_app.config['AVATAR_STATIC']
 
         if keyword not in static_images or keyword == '404':
             abort(404)
 
         image = Image.open(
-            url_for('static',
-                    filename=os.path.join('img', static_images[keyword]))
+            os.path.join(static_path, static_images[keyword])
         )
 
     # sizes


### PR DESCRIPTION
url_for percent encodes windows native paths and won't give the
correct path. Instead I use the already existing static path config for the proper path.

I hope this helps a bit, likely it is only needed for people that use windows to test lavatar ;-)